### PR TITLE
fixed typo in js filename + added way to provide custom form for inline

### DIFF
--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -16,11 +16,17 @@ from helpers import AdminErrorList
 class NestedModelAdmin(ModelAdmin):
     class Media:
         css = {'all': ('admin/css/nested.css',)}
-        js = ('admin/js/nested.js',)
+        js = ('admin/js/inlines.js',)
         
+    #Aliona: korekcijos, kad paimtu custom forma. Ideja paimta is cia: https://github.com/Soaa-/django-nested-inlines/pull/15
     def get_form(self, request, obj=None, **kwargs):
+        from django.forms.models import ModelForm
+        if self.form == ModelForm:
+            form = BaseNestedModelForm
+        else:
+            form = self.form
         return super(NestedModelAdmin, self).get_form(
-            request, obj, form=BaseNestedModelForm, **kwargs)
+            request, obj, form=form, **kwargs)
         
     def get_inline_instances(self, request, obj=None):
         inline_instances = []

--- a/nested_inlines/static/admin/js/inlines.js
+++ b/nested_inlines/static/admin/js/inlines.js
@@ -32,7 +32,7 @@
 		
 		if (isAddButtonVisible(options)) {
 			var addButton;
-			if ($this.attr("tagName") == "TR") {
+			if ($this.prop("tagName") == "TR") {
 				// If forms are laid out as table rows, insert the
 				// "add" button in a new table row:
 				var numCols = this.eq(-1).children().length;


### PR DESCRIPTION
This commit fixes typo / old JS filename and way to customize form for inline.
